### PR TITLE
Fix seeking song when clicking on "already-played" part

### DIFF
--- a/assets/player/PlayerControls.tsx
+++ b/assets/player/PlayerControls.tsx
@@ -62,7 +62,13 @@ const PlayerControls: React.FC<PlayerProps> = ({ currentTrack, controller, emitt
         }
 
         // We have to use e.target.
-        const slider = e.target as HTMLDivElement;
+        // Additionally, if user is clicking on the part that's hovered by the slider track (part of the
+        // song that was played so far) we have to refer to its parent to access the real slider element.
+        let slider = e.target as HTMLDivElement;
+        if (slider.classList.contains('player-position-slider-track')) {
+            slider = slider.parentElement as HTMLDivElement;
+        }
+
         const relativePosition = (e.pageX - slider.offsetLeft) / slider.offsetWidth;
         const position = totalDuration.fraction(relativePosition);
 


### PR DESCRIPTION
When the user clicked on the slider part that denoted already played portion of the song, the e.target pointed to a different element (.player-position-slider-track), making the calculation incorrect due to different slider.offsetLeft

I'm not sure if this way is correct and even then, checking the element by its class feels wrong to me. Hopefully we can come up with something better.

**Note:** this branch depends on `dependency-updates` because I'm dumb ;)